### PR TITLE
Optimize subset generation.

### DIFF
--- a/src/main/java/org/paukov/combinatorics3/SimpleSubSetIterator.java
+++ b/src/main/java/org/paukov/combinatorics3/SimpleSubSetIterator.java
@@ -22,7 +22,7 @@ class SimpleSubSetIterator<T> implements Iterator<List<T>> {
   private final SimpleSubSetGenerator<T> generator;
   private final int length;
 
-  private final List<T> currentSubSet = new ArrayList<>();
+  private final List<T> currentSubSet;
   private long currentIndex;
 
   /** Internal bit vector, representing the subset. */
@@ -31,6 +31,7 @@ class SimpleSubSetIterator<T> implements Iterator<List<T>> {
   SimpleSubSetIterator(final SimpleSubSetGenerator<T> generator) {
     this.generator = generator;
     this.length = generator.originalVector.size();
+    this.currentSubSet = new ArrayList<>(length);
     this.bitVector = new BitSet(length + 2);
     this.currentIndex = 0;
   }
@@ -53,12 +54,25 @@ class SimpleSubSetIterator<T> implements Iterator<List<T>> {
   @Override
   public List<T> next() {
     this.currentIndex++;
-    this.currentSubSet.clear();
-    for (int index = 1; index <= length; index++) {
-      if (bitVector.get(index)) {
-        currentSubSet.add(this.generator.originalVector.get(index - 1));
+    List<T> originalVector = this.generator.originalVector;
+    BitSet bitVector = this.bitVector;
+    int subSetSize = currentSubSet.size();
+    int j = 0;
+
+    for (int i = bitVector.nextSetBit(1); i >= 0; i = bitVector.nextSetBit(i + 1)) {
+      T e = originalVector.get(i - 1);
+      if (j < subSetSize) {
+        currentSubSet.set(j++, e);
+      } else {
+        currentSubSet.add(e);
       }
     }
+
+    // Do we have leftovers?
+    if (j < subSetSize) {
+      currentSubSet.subList(j, subSetSize).clear();
+    }
+
     int i = 1;
     while (bitVector.get(i)) {
       bitVector.clear(i);


### PR DESCRIPTION
This PR provides significant performance boost for subset generation. Firstly, when assembling a next subset, namely instead of
looping over original input and checking a subset state in the bit vector now we
are loop directly on bit vector. The second one is that we don't unconditionally clear content of internal list, but overwrite old elements and clear leftovers afterwards.

```
        Input Size          Time          Cleared
before          30      4m 33sec      16106127330
after           30      2m 22sec        536870882
```