### PR TITLE
Fix IndexOutOfBoundsException when generating permutation for empty list.

### DIFF
--- a/src/main/java/org/paukov/combinatorics3/EmptyGenerator.java
+++ b/src/main/java/org/paukov/combinatorics3/EmptyGenerator.java
@@ -1,0 +1,31 @@
+package org.paukov.combinatorics3;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Always empty stub generator.
+ */
+class EmptyGenerator<T> implements IGenerator<T> {
+  private static final EmptyGenerator<?> EMPTY = new EmptyGenerator<>();
+
+  private EmptyGenerator() {
+  }
+
+  static <T> EmptyGenerator<T> emptyGenerator() {
+    @SuppressWarnings("unchecked")
+    EmptyGenerator<T> g = (EmptyGenerator<T>) EMPTY;
+    return g;
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return Collections.emptyIterator();
+  }
+}

--- a/src/main/java/org/paukov/combinatorics3/PermutationGenerator.java
+++ b/src/main/java/org/paukov/combinatorics3/PermutationGenerator.java
@@ -9,6 +9,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.paukov.combinatorics3.EmptyGenerator.emptyGenerator;
+
 public class PermutationGenerator<T> {
 
   final Collection<T> originalVector;
@@ -44,7 +46,9 @@ public class PermutationGenerator<T> {
   }
 
   public IGenerator<List<T>> withRepetitions(int permutationLength) {
-    return new PermutationWithRepetitionGenerator<>(originalVector, permutationLength);
+    return originalVector.isEmpty()
+        ? emptyGenerator()
+        : new PermutationWithRepetitionGenerator<>(originalVector, permutationLength);
   }
 
   public enum TreatDuplicatesAs {

--- a/src/test/java/org/paukov/combinatorics3/PermutationsWithRepetitionsTest.java
+++ b/src/test/java/org/paukov/combinatorics3/PermutationsWithRepetitionsTest.java
@@ -8,6 +8,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -82,6 +83,16 @@ public final class PermutationsWithRepetitionsTest {
   }
 
   @Test
+  public void test_zero_permutation_of_empty_with_repetition() {
+    List<List<Object>> permutations = Generator.permutation(Collections.emptyList())
+        .withRepetitions(0)
+        .stream()
+        .collect(toList());
+
+    assertThat(permutations).isEmpty();
+  }
+
+  @Test
   public void test_zero_permutation_of_one_with_repetition() {
     List<List<String>> permutations = Generator.permutation("a")
         .withRepetitions(0)
@@ -91,7 +102,6 @@ public final class PermutationsWithRepetitionsTest {
     assertThat(permutations).hasSize(1);
     assertThat(permutations.get(0)).isEmpty();
   }
-
 
   @Test
   public void test_filter_permutation_of_with_repetition() {


### PR DESCRIPTION
Closes #19


